### PR TITLE
Use karto::ParameterManager to get available parameters and read those from ROS

### DIFF
--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -46,6 +46,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <locale> // for std::isupper, std::tolower
 
 #include <pluginlib/class_loader.h>
 
@@ -97,7 +98,7 @@ class SlamKarto
     double resolution_;
     boost::mutex map_mutex_;
     boost::mutex map_to_odom_mutex_;
-    
+
     std::string solver_type_;
     std::string visualizer_type_;
 
@@ -181,124 +182,39 @@ SlamKarto::SlamKarto() :
   mapper_ = new karto::Mapper();
   dataset_ = new karto::Dataset();
 
-  // Setting General Parameters from the Parameter Server
-  bool use_scan_matching;
-  if(private_nh_.getParam("use_scan_matching", use_scan_matching))
-    mapper_->setParamUseScanMatching(use_scan_matching);
-  
-  bool use_scan_barycenter;
-  if(private_nh_.getParam("use_scan_barycenter", use_scan_barycenter))
-    mapper_->setParamUseScanBarycenter(use_scan_barycenter);
-
-  double minimum_travel_distance;
-  if(private_nh_.getParam("minimum_travel_distance", minimum_travel_distance))
-    mapper_->setParamMinimumTravelDistance(minimum_travel_distance);
-
-  double minimum_travel_heading;
-  if(private_nh_.getParam("minimum_travel_heading", minimum_travel_heading))
-    mapper_->setParamMinimumTravelHeading(minimum_travel_heading);
-
-  int scan_buffer_size;
-  if(private_nh_.getParam("scan_buffer_size", scan_buffer_size))
-    mapper_->setParamScanBufferSize(scan_buffer_size);
-
-  double scan_buffer_maximum_scan_distance;
-  if(private_nh_.getParam("scan_buffer_maximum_scan_distance", scan_buffer_maximum_scan_distance))
-    mapper_->setParamScanBufferMaximumScanDistance(scan_buffer_maximum_scan_distance);
-
-  double link_match_minimum_response_fine;
-  if(private_nh_.getParam("link_match_minimum_response_fine", link_match_minimum_response_fine))
-    mapper_->setParamLinkMatchMinimumResponseFine(link_match_minimum_response_fine);
-
-  double link_scan_maximum_distance;
-  if(private_nh_.getParam("link_scan_maximum_distance", link_scan_maximum_distance))
-    mapper_->setParamLinkScanMaximumDistance(link_scan_maximum_distance);
-
-  double loop_search_maximum_distance;
-  if(private_nh_.getParam("loop_search_maximum_distance", loop_search_maximum_distance))
-    mapper_->setParamLoopSearchMaximumDistance(loop_search_maximum_distance);
-
-  bool do_loop_closing;
-  if(private_nh_.getParam("do_loop_closing", do_loop_closing))
-    mapper_->setParamDoLoopClosing(do_loop_closing);
-
-  int loop_match_minimum_chain_size;
-  if(private_nh_.getParam("loop_match_minimum_chain_size", loop_match_minimum_chain_size))
-    mapper_->setParamLoopMatchMinimumChainSize(loop_match_minimum_chain_size);
-
-  double loop_match_maximum_variance_coarse;
-  if(private_nh_.getParam("loop_match_maximum_variance_coarse", loop_match_maximum_variance_coarse))
-    mapper_->setParamLoopMatchMaximumVarianceCoarse(loop_match_maximum_variance_coarse);
-
-  double loop_match_minimum_response_coarse;
-  if(private_nh_.getParam("loop_match_minimum_response_coarse", loop_match_minimum_response_coarse))
-    mapper_->setParamLoopMatchMinimumResponseCoarse(loop_match_minimum_response_coarse);
-
-  double loop_match_minimum_response_fine;
-  if(private_nh_.getParam("loop_match_minimum_response_fine", loop_match_minimum_response_fine))
-    mapper_->setParamLoopMatchMinimumResponseFine(loop_match_minimum_response_fine);
-
-  // Setting Correlation Parameters from the Parameter Server
-
-  double correlation_search_space_dimension;
-  if(private_nh_.getParam("correlation_search_space_dimension", correlation_search_space_dimension))
-    mapper_->setParamCorrelationSearchSpaceDimension(correlation_search_space_dimension);
-
-  double correlation_search_space_resolution;
-  if(private_nh_.getParam("correlation_search_space_resolution", correlation_search_space_resolution))
-    mapper_->setParamCorrelationSearchSpaceResolution(correlation_search_space_resolution);
-
-  double correlation_search_space_smear_deviation;
-  if(private_nh_.getParam("correlation_search_space_smear_deviation", correlation_search_space_smear_deviation))
-    mapper_->setParamCorrelationSearchSpaceSmearDeviation(correlation_search_space_smear_deviation);
-
-  // Setting Correlation Parameters, Loop Closure Parameters from the Parameter Server
-
-  double loop_search_space_dimension;
-  if(private_nh_.getParam("loop_search_space_dimension", loop_search_space_dimension))
-    mapper_->setParamLoopSearchSpaceDimension(loop_search_space_dimension);
-
-  double loop_search_space_resolution;
-  if(private_nh_.getParam("loop_search_space_resolution", loop_search_space_resolution))
-    mapper_->setParamLoopSearchSpaceResolution(loop_search_space_resolution);
-
-  double loop_search_space_smear_deviation;
-  if(private_nh_.getParam("loop_search_space_smear_deviation", loop_search_space_smear_deviation))
-    mapper_->setParamLoopSearchSpaceSmearDeviation(loop_search_space_smear_deviation);
-
-  // Setting Scan Matcher Parameters from the Parameter Server
-
-  double distance_variance_penalty;
-  if(private_nh_.getParam("distance_variance_penalty", distance_variance_penalty))
-    mapper_->setParamDistanceVariancePenalty(distance_variance_penalty);
-
-  double angle_variance_penalty;
-  if(private_nh_.getParam("angle_variance_penalty", angle_variance_penalty))
-    mapper_->setParamAngleVariancePenalty(angle_variance_penalty);
-
-  double fine_search_angle_offset;
-  if(private_nh_.getParam("fine_search_angle_offset", fine_search_angle_offset))
-    mapper_->setParamFineSearchAngleOffset(fine_search_angle_offset);
-
-  double coarse_search_angle_offset;
-  if(private_nh_.getParam("coarse_search_angle_offset", coarse_search_angle_offset))
-    mapper_->setParamCoarseSearchAngleOffset(coarse_search_angle_offset);
-
-  double coarse_angle_resolution;
-  if(private_nh_.getParam("coarse_angle_resolution", coarse_angle_resolution))
-    mapper_->setParamCoarseAngleResolution(coarse_angle_resolution);
-
-  double minimum_angle_penalty;
-  if(private_nh_.getParam("minimum_angle_penalty", minimum_angle_penalty))
-    mapper_->setParamMinimumAnglePenalty(minimum_angle_penalty);
-
-  double minimum_distance_penalty;
-  if(private_nh_.getParam("minimum_distance_penalty", minimum_distance_penalty))
-    mapper_->setParamMinimumDistancePenalty(minimum_distance_penalty);
-
-  bool use_response_expansion;
-  if(private_nh_.getParam("use_response_expansion", use_response_expansion))
-    mapper_->setParamUseResponseExpansion(use_response_expansion);
+  // Read karto parameters from ROS if they are present:
+  // For each karto parameter name, if that parameter is set in ROS,
+  // read the parameter and set it in karto.
+  const karto::ParameterVector& mapper_parameters = mapper_->GetParameters();
+  for (karto::ParameterVector::const_iterator iter = mapper_parameters.begin();
+         iter != mapper_parameters.end(); ++iter) {
+    std::string karto_parameter_name = (*iter)->GetName();
+    // Karto parameter names are in CamelCase, ROS parameters are in under_scores,
+    // so we have to convert.
+    std::string ros_parameter_name;
+    for (std::string::iterator str_it = karto_parameter_name.begin(); str_it != karto_parameter_name.end(); ++ str_it) {
+      if (str_it != karto_parameter_name.begin() && std::isupper(*str_it)) {
+        ros_parameter_name += '_';
+      }
+      ros_parameter_name += std::tolower(*str_it);
+    }
+    XmlRpc::XmlRpcValue ros_parameter_value;
+    if (private_nh_.getParam(ros_parameter_name, ros_parameter_value)) {
+      switch (ros_parameter_value.getType()) {
+        case XmlRpc::XmlRpcValue::TypeBoolean:  mapper_->SetParameter(karto_parameter_name, static_cast<bool>(ros_parameter_value)); break;
+        case XmlRpc::XmlRpcValue::TypeInt:      mapper_->SetParameter(karto_parameter_name, static_cast<int>(ros_parameter_value)); break;
+        case XmlRpc::XmlRpcValue::TypeDouble:   mapper_->SetParameter(karto_parameter_name, static_cast<double>(ros_parameter_value)); break;
+        case XmlRpc::XmlRpcValue::TypeString:   mapper_->SetParameter(karto_parameter_name, static_cast<std::string>(ros_parameter_value)); break;
+        default: ROS_WARN_STREAM("Cannot set " << ros_parameter_name << ": Unsupported parameter type. Leaving default: "
+                     << mapper_->GetParameter(karto_parameter_name)->GetValueAsString()); continue;
+      }
+      ROS_INFO_STREAM("Set " << ros_parameter_name << " (" << karto_parameter_name << " in karto) to "
+          << mapper_->GetParameter(karto_parameter_name)->GetValueAsString());
+    } else {
+      ROS_INFO_STREAM("No ROS parameter " << ros_parameter_name << " set, using karto default: "
+          << mapper_->GetParameter(karto_parameter_name)->GetValueAsString());
+    }
+  }
 
   // Set solver to be used in loop closure
   std::stringstream solver_plugin_stream;


### PR DESCRIPTION
This removes the need from adding setters/getter to open_karto::Mapper,
with this open_karto@66b832 can be reverted.

Getting the parameter names directly from karto also removes the need for
patching slam_karto whenever a new parameter is exposed in
open_karto::Mapper.

Example output setting some parameters:
```
$ rosrun slam_karto slam_karto _minimum_travel_heading:=0.2 _use_scan_barycenter:=false _scan_buffer_size:=50
1490783198.511400848 /slam_karto [ INFO] No ROS parameter use_scan_matching set, using karto default: true
1490783198.511709027 /slam_karto [ INFO] Set use_scan_barycenter (UseScanBarycenter in karto) to false
1490783198.511980091 /slam_karto [ INFO] No ROS parameter minimum_travel_distance set, using karto default: 0.2
1490783198.512263094 /slam_karto [ INFO] Set minimum_travel_heading (MinimumTravelHeading in karto) to 0.2
1490783198.512533131 /slam_karto [ INFO] Set scan_buffer_size (ScanBufferSize in karto) to 50
1490783198.512798596 /slam_karto [ INFO] No ROS parameter scan_buffer_maximum_scan_distance set, using karto default: 20
1490783198.513063722 /slam_karto [ INFO] No ROS parameter link_match_minimum_response_fine set, using karto default: 0.8
1490783198.513327609 /slam_karto [ INFO] No ROS parameter link_scan_maximum_distance set, using karto default: 10
1490783198.513591644 /slam_karto [ INFO] No ROS parameter loop_search_maximum_distance set, using karto default: 4
1490783198.513846981 /slam_karto [ INFO] No ROS parameter do_loop_closing set, using karto default: true
1490783198.514105925 /slam_karto [ INFO] No ROS parameter loop_match_minimum_chain_size set, using karto default: 10
1490783198.514365556 /slam_karto [ INFO] No ROS parameter loop_match_maximum_variance_coarse set, using karto default: 0.16
1490783198.514632911 /slam_karto [ INFO] No ROS parameter loop_match_minimum_response_coarse set, using karto default: 0.8
1490783198.514895211 /slam_karto [ INFO] No ROS parameter loop_match_minimum_response_fine set, using karto default: 0.8
1490783198.515157721 /slam_karto [ INFO] No ROS parameter correlation_search_space_dimension set, using karto default: 0.3
1490783198.515417754 /slam_karto [ INFO] No ROS parameter correlation_search_space_resolution set, using karto default: 0.01
1490783198.515680383 /slam_karto [ INFO] No ROS parameter correlation_search_space_smear_deviation set, using karto default: 0.03
1490783198.515940399 /slam_karto [ INFO] No ROS parameter loop_search_space_dimension set, using karto default: 8
1490783198.516261480 /slam_karto [ INFO] No ROS parameter loop_search_space_resolution set, using karto default: 0.05
1490783198.516569127 /slam_karto [ INFO] No ROS parameter loop_search_space_smear_deviation set, using karto default: 0.03
1490783198.516865417 /slam_karto [ INFO] No ROS parameter distance_variance_penalty set, using karto default: 0.09
1490783198.517150193 /slam_karto [ INFO] No ROS parameter angle_variance_penalty set, using karto default: 0.121846967914683
1490783198.517432194 /slam_karto [ INFO] No ROS parameter fine_search_angle_offset set, using karto default: 0.00349065850398866
1490783198.517714391 /slam_karto [ INFO] No ROS parameter coarse_search_angle_offset set, using karto default: 0.349065850398866
1490783198.517996078 /slam_karto [ INFO] No ROS parameter coarse_angle_resolution set, using karto default: 0.0349065850398866
1490783198.518276274 /slam_karto [ INFO] No ROS parameter minimum_angle_penalty set, using karto default: 0.9
1490783198.518558157 /slam_karto [ INFO] No ROS parameter minimum_distance_penalty set, using karto default: 0.5
1490783198.518845310 /slam_karto [ INFO] No ROS parameter use_response_expansion set, using karto default: false
```